### PR TITLE
Reenabled Mockito test after adding dependencies.

### DIFF
--- a/RealWorldSoftwareDevelopment.iml
+++ b/RealWorldSoftwareDevelopment.iml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="JUnit5.4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.4.2/junit-jupiter-5.4.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.4.2/junit-jupiter-api-5.4.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.4.2/junit-platform-commons-1.4.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.4.2/junit-jupiter-params-5.4.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.4.2/junit-jupiter-engine-5.4.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.4.2/junit-platform-engine-1.4.2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/Downloads/mockito-core-3.6.28.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/Downloads/byte-buddy-1.10.18.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/Downloads/byte-buddy-agent-1.10.18.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/Downloads/objenesis-3.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/src/test/java/chapter5/BusinessRuleEngineTest.java
+++ b/src/test/java/chapter5/BusinessRuleEngineTest.java
@@ -4,8 +4,7 @@ import main.java.chapter5.Action;
 import main.java.chapter5.BusinessRuleEngine;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-//import org.mockito.Mockito;
-
+import org.mockito.Mockito;
 
 public class BusinessRuleEngineTest {
 
@@ -26,15 +25,15 @@ public class BusinessRuleEngineTest {
         Assertions.assertEquals(2, businessRuleEngine.count());
     }
 
-/* Uncomment after creating a gradle or maven build file to handle external libraries */
-//    @Test
-//    void shouldExecuteOneAction() {
-//        final BusinessRuleEngine businessRuleEngine = new BusinessRuleEngine();
-//        final Action mockAction = Mockito.mock(Action.class);
-//
-//        businessRuleEngine.addAction(mockAction);
-//        businessRuleEngine.run();
-//
-//        Mockito.verify(mockAction).execute();
-//    }
+    /* Uncomment after creating a gradle or maven build file to handle external libraries */
+    @Test
+    void shouldExecuteOneAction() {
+        final BusinessRuleEngine businessRuleEngine = new BusinessRuleEngine();
+        final Action mockAction = Mockito.mock(Action.class);
+
+        businessRuleEngine.addAction(mockAction);
+        businessRuleEngine.run();
+
+        Mockito.verify(mockAction).execute();
+    }
 }


### PR DESCRIPTION
Unit test using Mockito was throwing errors. The issue was that the Mockito jar has 3 dependencies. I added them to the project and added IntelliJ's build file to the repository. 

Link to Mockito's dependencies for the version I am using:
https://mvnrepository.com/artifact/org.mockito/mockito-core/3.6.28